### PR TITLE
Hide version select box

### DIFF
--- a/themes/vue/layout/partials/sidebar.ejs
+++ b/themes/vue/layout/partials/sidebar.ejs
@@ -23,14 +23,14 @@
         <% } else if (type === 'examples') { %>
           Một số ví dụ
         <% } %>      
-        <% if (['cookbook', 'style-guide'].indexOf(type) === -1) { %>
+        <%/* if (['cookbook', 'style-guide'].indexOf(type) === -1) { %>
           <select class="version-select">
             <option value="SELF" selected>2.x</option>
             <option value="v1">1.0</option>
             <option value="012">0.12</option>
             <option value="011">0.11</option>
           </select>
-        <% } %>
+        <% } */%>
       </h2>
       <%- partial('partials/toc', { type: type }) %>
     </div>


### PR DESCRIPTION
We’re not translating versions lower than v2, so the select box should be hidden for now.